### PR TITLE
fix!: split leave button to prevent desyncing

### DIFF
--- a/commands/example/onleave.js
+++ b/commands/example/onleave.js
@@ -30,8 +30,12 @@ exports.slash = async (client, interaction) => {
         ],
         components: [
             new ActionRowBuilder().addComponents(new ButtonBuilder()
-                .setLabel("Switch On Leave Status")
-                .setCustomId("onleave")
+                .setLabel("Go On Leave")
+                .setCustomId("onleave/onleave")
+                .setStyle(2)),
+            new ActionRowBuilder().addComponents(new ButtonBuilder()
+                .setLabel("Return From Leave")
+                .setCustomId("onleave/back")
                 .setStyle(2))
         ]
 
@@ -58,17 +62,18 @@ exports.modal = async (client, interaction) => {
         let guild = await client.guilds.cache.get(key.split("|")[0])
         let guildMember = await guild.members.fetch(interaction.user.id)
 
+        let goingOnLeave = interaction.customId === "onleave/onleave";
 
         let newRoles = value.reduce((cache, [role1ID, role2ID]) => {
             let role1 = guild.roles.cache.get(role1ID)
             let role2 = guild.roles.cache.get(role2ID)
 
-            if (guildMember.roles.cache.has(role1ID)) {
+            if (guildMember.roles.cache.has(role1ID) && goingOnLeave) {
                 if (guild.id == interaction.guild.id) switched[winDex].value.push(`Switched <@&${role1ID}> -> <@&${role2ID}>`)
                 else switched[winDex].value.push(`Switched ${role1.name} -> ${role2.name}`)
                 cache.delete(role1ID)
                 cache.add(role2ID)
-            } else if (guildMember.roles.cache.has(role2ID)) {
+            } else if (guildMember.roles.cache.has(role2ID) && !goingOnLeave) {
                 if (guild.id == interaction.guild.id) switched[winDex].value.push(`Switched <@&${role2ID}> -> <@&${role1ID}>`)
                 else switched[winDex].value.push(`Switched ${role2.name} -> ${role1.name}`)
                 cache.delete(role2ID)
@@ -112,7 +117,7 @@ exports.modal = async (client, interaction) => {
 }
 exports.button = async (client, interaction) => {
     await interaction.showModal(new ModalBuilder()
-        .setCustomId(`onleave`)
+        .setCustomId(interaction.customId)
         .setTitle(`The following information is optional.`)
         .addComponents([
             new ActionRowBuilder().addComponents([


### PR DESCRIPTION
We've had some issues with roles desyncing still, and I'm fed up of trying to debug this when it's neither common nor reliably reproducible ... so let's not! If, instead, we split the leave button into a "go on leave" and a "come back from leave" then even if roles do get desynced the staff member can easily apply the desired leave again...

BREAKING-CHANGE: This changes the leave button, so the leave message will need to be sent again. It also strictly requires "on leave" roles to be listed after regular roles in the config